### PR TITLE
Add website URL to resume

### DIFF
--- a/components/resume-content.tsx
+++ b/components/resume-content.tsx
@@ -31,6 +31,11 @@ export function ResumeContent({ data }: ResumeContentProps) {
           <p>
             <a href={`mailto:${basics.email}`}>{basics.email}</a>
           </p>
+          {basics.url && (
+            <p>
+              <a href={basics.url}>{basics.url.replace(/^https?:\/\//, "")}</a>
+            </p>
+          )}
           {basics.phone && <p>{basics.phone}</p>}
           {basics.profiles?.map((profile) => (
             <p key={profile.network}>

--- a/types/images.d.ts
+++ b/types/images.d.ts
@@ -1,0 +1,40 @@
+declare module "*.webp" {
+  import { StaticImageData } from "next/image";
+  const content: StaticImageData;
+  export default content;
+}
+
+declare module "*.png" {
+  import { StaticImageData } from "next/image";
+  const content: StaticImageData;
+  export default content;
+}
+
+declare module "*.jpg" {
+  import { StaticImageData } from "next/image";
+  const content: StaticImageData;
+  export default content;
+}
+
+declare module "*.jpeg" {
+  import { StaticImageData } from "next/image";
+  const content: StaticImageData;
+  export default content;
+}
+
+declare module "*.gif" {
+  import { StaticImageData } from "next/image";
+  const content: StaticImageData;
+  export default content;
+}
+
+declare module "*.svg" {
+  const content: string;
+  export default content;
+}
+
+declare module "@/public/*" {
+  import { StaticImageData } from "next/image";
+  const content: StaticImageData;
+  export default content;
+}


### PR DESCRIPTION
## Summary
Adds display of website URL (rioedwards.com) to the resume contact section.

## Changes
- Updated `resume-content.tsx` to display the `basics.url` field from the resume data
- The URL is shown between email and phone number, formatted without the protocol (displays as "rioedwards.com")
- Added TypeScript declarations for image imports in `types/images.d.ts` to resolve pre-existing type errors

## Notes
The resume data in your GitHub Gist already includes the website URL field, so no changes to the data source were needed.

---
_This PR was generated with [Warp](https://www.warp.dev/)._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Website URLs now display as clickable links in the contact information section, with automatic formatting for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->