### PR TITLE
fix(resume): responsive layout overhaul for mobile and tablet

### DIFF
--- a/app/resume.css
+++ b/app/resume.css
@@ -221,7 +221,7 @@
   }
 
   .entry-title-block {
-    gap: 2px;
+    gap: calc(var(--base-space) * 0.25);
   }
 
   .entry-company,
@@ -476,10 +476,7 @@
   }
 
   .entry-position,
-  .entry-company {
-    display: inline;
-  }
-
+  .entry-company,
   .entry-institution {
     display: inline;
   }

--- a/components/resume-content.tsx
+++ b/components/resume-content.tsx
@@ -57,10 +57,10 @@ export function ResumeContent({ data }: ResumeContentProps) {
             <div key={`${job.name}-${job.startDate}`} className="entry">
               <div className="entry-header">
                 <div className="entry-title-block">
-                  <p className="entry-position">
+                  <span className="entry-position">
                     <strong>{job.position}</strong>
-                  </p>
-                  <p className="entry-company">{job.name}</p>
+                  </span>
+                  <span className="entry-company">{job.name}</span>
                 </div>
                 <p className="entry-meta">
                   {formatResumeDate(job.startDate)}
@@ -117,7 +117,9 @@ export function ResumeContent({ data }: ResumeContentProps) {
                       {title}
                       {area}
                     </strong>
-                    <span className="entry-institution">{subtitle}</span>
+                    {subtitle && (
+                      <span className="entry-institution">{subtitle}</span>
+                    )}
                   </p>
                   {date && (
                     <p className="entry-meta">{formatResumeDate(date)}</p>


### PR DESCRIPTION
## Summary

- Splits experience entries into separate position/company elements and education entries into title/institution spans, enabling independent styling at each breakpoint
- Implements a three-state responsive layout for all entries: wide (≥800px) shows everything inline with date on the right, medium (560–799px) keeps title+company/institution on one line with date above, and narrow (<560px) stacks all elements with date on top
- Aligns the skills section breakpoint with entries at 800px to prevent inconsistent row wrapping
- Adds faint horizontal dividers between entries at all screen widths
- Adds an `@` prefix before company/institution names in the narrow stacked layout
- Applies clear three-tier visual hierarchy in stacked layouts: bold title (primary), smaller muted company/institution (secondary), small italic date (tertiary)
- Colors section headings (EXPERIENCE, SKILLS, EDUCATION) with the same green accent as the name

## Test plan

- [ ] Verify wide layout (≥800px): all entries show title+company/institution inline with date on the right
- [ ] Verify medium layout (560–799px): title+company/institution on one line, date above
- [ ] Verify narrow layout (<560px): date, title, and company/institution each on their own line with `@` prefix and faint dividers
- [ ] Verify skills section stacks below 800px and goes side-by-side above
- [ ] Verify print/PDF output is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Style
- Redesigned resume entries into a multi-part header for clearer position, company/institution and dates
- Improved spacing, responsive stacking/inline behavior across narrow, medium and wide viewports
- Added subtle separators and trailing comma styling for clearer reading
- Tightened typography and hierarchy at key breakpoints
- Refined print styling for consistent screen-to-print appearance and spacing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->