### PR TITLE
Add projects section to resume JSON schema

### DIFF
--- a/app/resume.css
+++ b/app/resume.css
@@ -277,6 +277,11 @@
   font-size: var(--font-small);
 }
 
+.entry-description {
+  margin-top: var(--space-xs);
+  line-height: 1.5;
+}
+
 /* ===== Bullets ===== */
 
 .bullets {

--- a/components/resume-content.tsx
+++ b/components/resume-content.tsx
@@ -3,6 +3,7 @@ import {
   Resume,
   ResumeCertificate,
   ResumeEducation,
+  ResumeProject,
   formatResumeDate,
 } from "@/lib/resume";
 
@@ -11,7 +12,7 @@ interface ResumeContentProps {
 }
 
 export function ResumeContent({ data }: ResumeContentProps) {
-  const { basics, work, education, certificates, skills } = data;
+  const { basics, work, education, certificates, skills, projects } = data;
 
   // Combine certificates and education for display
   const allEducation: (ResumeEducation | ResumeCertificate)[] = [
@@ -76,6 +77,53 @@ export function ResumeContent({ data }: ResumeContentProps) {
               )}
             </div>
           ))}
+
+          {/* Projects (rendered as part of Experience section) */}
+          {projects && projects.length > 0 && (
+            <>
+              {projects.map((project: ResumeProject) => (
+                <div
+                  key={`${project.name}-${project.startDate}`}
+                  className="entry"
+                >
+                  <div className="entry-header">
+                    <div className="entry-title-block">
+                      <span className="entry-position">
+                        <strong>{project.name}</strong>
+                      </span>
+                      {project.url && (
+                        <a
+                          href={project.url}
+                          className="entry-company"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          {project.url.replace(/^https?:\/\//, "")}
+                        </a>
+                      )}
+                    </div>
+                    {project.startDate && (
+                      <p className="entry-meta">
+                        {formatResumeDate(project.startDate)}
+                        {project.endDate &&
+                          ` - ${formatResumeDate(project.endDate)}`}
+                      </p>
+                    )}
+                  </div>
+                  {project.description && (
+                    <p className="entry-description">{project.description}</p>
+                  )}
+                  {project.highlights && project.highlights.length > 0 && (
+                    <ul className="bullets">
+                      {project.highlights.map((highlight, i) => (
+                        <li key={i}>{highlight}</li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+              ))}
+            </>
+          )}
         </section>
       )}
 

--- a/lib/resume.ts
+++ b/lib/resume.ts
@@ -45,6 +45,15 @@ export interface ResumeSkill {
   keywords?: string[];
 }
 
+export interface ResumeProject {
+  name: string;
+  startDate?: string;
+  endDate?: string;
+  description?: string;
+  highlights?: string[];
+  url?: string;
+}
+
 export interface Resume {
   $schema?: string;
   basics: ResumeBasics;
@@ -52,6 +61,7 @@ export interface Resume {
   education?: ResumeEducation[];
   certificates?: ResumeCertificate[];
   skills?: ResumeSkill[];
+  projects?: ResumeProject[];
 }
 
 const GIST_RAW_URL =


### PR DESCRIPTION
## Summary
Add support for a `projects` section in the resume JSON schema, following the standard [JSON Resume](https://jsonresume.org/schema) format. Projects are rendered under the Experience section, styled consistently with work entries.

## Changes
- **`lib/resume.ts`**: Added `ResumeProject` interface and `projects` field to the `Resume` interface
- **`components/resume-content.tsx`**: Updated to render projects below work entries in the Experience section
- **`app/resume.css`**: Added `.entry-description` class for project descriptions

## JSON Resume Schema Format
```json
{
  "projects": [{
    "name": "Project Name",
    "startDate": "2019-01-01",
    "endDate": "2021-01-01",
    "description": "Description...",
    "highlights": ["Achievement 1", "Achievement 2"],
    "url": "https://project.com/"
  }]
}
```

## Visual Integration
Projects appear seamlessly within the Experience section:
- Project name displayed as the primary title (like job position)
- URL displayed as secondary info (like company name), clickable with external link
- Date range displayed in the same italic style as work entries
- Description and highlights rendered consistently with work entry formatting

_This PR was generated with [Warp](https://www.warp.dev/)._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new Projects section to the resume, displaying each project with details including name, URL, date range, description, and highlights.
  * Enhanced visual styling for resume entry descriptions with improved spacing and line-height adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->