### PR TITLE
rebrand(site): update title and metadata from software engineer to product engineer

### DIFF
--- a/app/(home)/layout.tsx
+++ b/app/(home)/layout.tsx
@@ -6,7 +6,7 @@ export const metadata: Metadata = {
     absolute: "Rio Edwards | Portfolio",
   },
   description:
-    "Software engineer specializing in full-stack web development. View my projects, experience, and get in touch.",
+    "Product engineer building and shipping production software used by real teams. View my projects, experience, and get in touch.",
 };
 
 export default function HomeLayout({

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -70,9 +70,9 @@ const jsonLd = {
   "@type": "Person",
   name: "Rio Edwards",
   url: siteUrl,
-  jobTitle: "Software Engineer",
+  jobTitle: "Product Engineer",
   description:
-    "Software engineer specializing in full-stack web development with React, Next.js, and TypeScript.",
+    "Product engineer building and shipping production web and mobile apps with React, Next.js, and TypeScript.",
   sameAs: [
     "https://github.com/rioredwards",
     "https://linkedin.com/in/rioredwards",
@@ -82,12 +82,13 @@ const jsonLd = {
 
 export const metadata: Metadata = {
   title: {
-    default: "Rio Edwards | Software Engineer",
-    template: "%s — Rio Edwards",
+    default: "Rio Edwards | Product Engineer",
+    template: "%s | Rio Edwards",
   },
   description:
-    "Software engineer specializing in full-stack web development. View my projects, experience, and get in touch.",
+    "Product engineer building and shipping production software used by real teams. View my projects, experience, and get in touch.",
   keywords: [
+    "product engineer",
     "software engineer",
     "web developer",
     "full-stack developer",
@@ -112,15 +113,15 @@ export const metadata: Metadata = {
     locale: "en_US",
     url: siteUrl,
     siteName: "Rio Edwards",
-    title: "Rio Edwards | Software Engineer",
+    title: "Rio Edwards | Product Engineer",
     description:
-      "Software engineer specializing in full-stack web development. View my projects, experience, and get in touch.",
+      "Product engineer building and shipping production software used by real teams. View my projects, experience, and get in touch.",
   },
   twitter: {
     card: "summary_large_image",
-    title: "Rio Edwards | Software Engineer",
+    title: "Rio Edwards | Product Engineer",
     description:
-      "Software engineer specializing in full-stack web development. View my projects, experience, and get in touch.",
+      "Product engineer building and shipping production software used by real teams. View my projects, experience, and get in touch.",
   },
   robots: {
     index: true,

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -2,7 +2,7 @@ import { ImageResponse } from "next/og";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 
-export const alt = "Rio Edwards — Software Engineer";
+export const alt = "Rio Edwards — Product Engineer";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
 

--- a/app/resume/page.tsx
+++ b/app/resume/page.tsx
@@ -6,11 +6,11 @@ import type { Metadata } from "next";
 export const metadata: Metadata = {
   title: "Resume",
   description:
-    "Rio Edwards - Software Engineer resume. Experience in full-stack web development with React, Next.js, TypeScript, and Node.js.",
+    "Product Engineer resume for Rio Edwards. Full-stack web development with React, Next.js, TypeScript, and Node.js.",
   openGraph: {
-    title: "Resume — Rio Edwards",
+    title: "Resume | Rio Edwards",
     description:
-      "Rio Edwards - Software Engineer resume. Experience in full-stack web development with React, Next.js, TypeScript, and Node.js.",
+      "Product Engineer resume for Rio Edwards. Full-stack web development with React, Next.js, TypeScript, and Node.js.",
   },
 };
 

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,7 +1,7 @@
 {
-  "name": "Rio Edwards | Software Engineer",
+  "name": "Rio Edwards | Product Engineer",
   "short_name": "Rio Edwards",
-  "description": "Software engineer specializing in full-stack web development",
+  "description": "Product engineer building and shipping production software used by real teams",
   "start_url": "/",
   "display": "standalone",
   "background_color": "#ecdfca",


### PR DESCRIPTION
## Summary

- Replace "Software Engineer" with "Product Engineer" across all metadata, JSON-LD, OG tags, Twitter cards, and webmanifest
- Tighten description copy to "building and shipping production software used by real teams"
- Add "software engineer" back to keywords array for SEO coverage
- Fix em dashes in title templates (use | separator to match existing style)
- Fix resume page OG title and description phrasing

## Test plan

- [ ] Check page title in browser tab reads "Rio Edwards | Product Engineer"
- [ ] Inspect OG tags and confirm updated descriptions
- [ ] Verify "software engineer" still appears in meta keywords

🤖 Generated with [Claude Code](https://claude.com/claude-code)