### PR TITLE
fix(resume): show 'personal project' label instead of URL link

### DIFF
--- a/components/resume-content.tsx
+++ b/components/resume-content.tsx
@@ -125,16 +125,7 @@ export function ResumeContent({ data }: ResumeContentProps) {
                       <span className="entry-position">
                         <strong>{project.name}</strong>
                       </span>
-                      {project.url && (
-                        <a
-                          href={project.url}
-                          className="entry-company"
-                          target="_blank"
-                          rel="noopener noreferrer"
-                        >
-                          {project.url.replace(/^https?:\/\//, "")}
-                        </a>
-                      )}
+                      <span className="entry-company">personal project</span>
                     </div>
                     {project.startDate && (
                       <p className="entry-meta">


### PR DESCRIPTION
## Summary

- Replace project URL link with a static "personal project" label in the resume projects section
- Remove conditional URL rendering to simplify the display

This fix was on local dev but wasn't included in any of the recent PRs.

## Test plan

- [ ] Visit /resume and confirm the DogTown entry shows "personal project" instead of a clickable URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)