### PR TITLE
perf: make /blog and /work statically prerendered

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,21 +1,11 @@
-import { BlogModalHandler, type RenderedBlog } from "@/components/blog";
-import { ChipOverflowRow } from "@/components/chip-overflow-row";
-import { FilterChipGroup } from "@/components/filter-chip-group";
+import { BlogListClient } from "@/components/blog/blog-list-client";
+import { type RenderedBlog } from "@/components/blog/blog-modal-handler";
 import { Footer, SectionContentWrapper } from "@/components/layout";
 import { ListPageHeader } from "@/components/list-page-header";
 import { mdxComponents } from "@/components/mdx";
-import { PaginationNav } from "@/components/pagination-nav";
-import { SearchInput } from "@/components/search-input";
-import { getBlogIcon } from "@/lib/blog-icons";
-import { getAllBlogCards, getAllBlogsWithContent } from "@/lib/blogs";
-import { DEFAULT_LOCALE } from "@/lib/constants";
-import { paginateItems, parsePageParam } from "@/lib/pagination";
-import { buildQueryHref, readSingleParam } from "@/lib/query-params";
-import { searchBlogs } from "@/lib/search";
-import { sortBlogs } from "@/lib/sorting";
-import { cn } from "@/lib/utils";
+import { getAllBlogsWithContent } from "@/lib/blogs";
+import { sortByOrder } from "@/lib/sorting";
 import type { Metadata } from "next";
-import Link from "next/link";
 import { MDXRemote } from "next-mdx-remote/rsc";
 import { Suspense } from "react";
 
@@ -32,69 +22,12 @@ export const metadata: Metadata = {
   },
 };
 
-function formatPublishedDate(date?: string) {
-  if (!date) return null;
-
-  return new Intl.DateTimeFormat(DEFAULT_LOCALE, {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-    timeZone: "UTC",
-  }).format(new Date(`${date}T00:00:00Z`));
-}
-
-const BLOGS_PER_PAGE = 9;
-
-interface BlogIndexPageProps {
-  searchParams?: Promise<{
-    page?: string | string[];
-    tag?: string | string[];
-    q?: string | string[];
-  }>;
-}
-
-export default async function BlogIndexPage({
-  searchParams,
-}: BlogIndexPageProps) {
-  const resolvedSearchParams = await searchParams;
-  const selectedTag = readSingleParam(resolvedSearchParams?.tag);
-  const searchQuery = readSingleParam(resolvedSearchParams?.q);
-  const blogs = getAllBlogCards();
+export default async function BlogIndexPage() {
   const blogsWithContent = getAllBlogsWithContent();
-  const tagOptions = [
-    ...new Set(
-      Array.from(blogsWithContent.values()).flatMap(
-        (blog) => blog.frontmatter.tags ?? [],
-      ),
-    ),
-  ];
-  const filteredBlogs = selectedTag
-    ? blogs.filter((blog) => {
-        const blogWithContent = blogsWithContent.get(blog.slug);
-        return (blogWithContent?.frontmatter.tags ?? []).includes(selectedTag);
-      })
-    : blogs;
-  const searchedBlogs = searchBlogs(
-    filteredBlogs,
-    searchQuery,
-    (blog) => blogsWithContent.get(blog.slug)?.frontmatter.tags ?? [],
+
+  const blogFrontmatters = sortByOrder(
+    Array.from(blogsWithContent.values()).map((b) => b.frontmatter),
   );
-  const sortedBlogs = sortBlogs(
-    searchedBlogs,
-    undefined,
-    (blog) => blogsWithContent.get(blog.slug)?.frontmatter.date,
-  );
-  const totalPages = Math.max(
-    1,
-    Math.ceil(sortedBlogs.length / BLOGS_PER_PAGE),
-  );
-  const currentPage = parsePageParam(resolvedSearchParams?.page, totalPages);
-  const paginatedBlogs = paginateItems(
-    sortedBlogs,
-    currentPage,
-    BLOGS_PER_PAGE,
-  );
-  const hasResults = paginatedBlogs.totalItems > 0;
 
   const renderedBlogs = new Map<string, RenderedBlog>();
   for (const [slug, blog] of blogsWithContent) {
@@ -110,12 +43,6 @@ export default async function BlogIndexPage({
     });
   }
 
-  const blogListQuery = {
-    tag: selectedTag,
-    q: searchQuery,
-    page: currentPage > 1 ? currentPage : null,
-  };
-
   return (
     <>
       <main id="main-content" className="relative min-h-screen bg-secondary">
@@ -124,149 +51,15 @@ export default async function BlogIndexPage({
             title="Blog"
             subtitle="Notes on software, systems, and design decisions from real product work."
           />
-
-          <section aria-label="Blog posts list" className="space-y-3.5">
-            <SearchInput
-              basePath="/blog"
-              currentValue={searchQuery}
-              placeholder="Search by title, tag, or description…"
-              preserveParams={{ tag: selectedTag }}
+          <Suspense>
+            <BlogListClient
+              blogFrontmatters={blogFrontmatters}
+              renderedBlogs={renderedBlogs}
             />
-
-            <FilterChipGroup
-              title="Filter by tag"
-              basePath="/blog"
-              paramName="tag"
-              selectedValue={selectedTag}
-              options={tagOptions.map((tag) => ({
-                label: tag,
-                value: tag,
-              }))}
-              preserveParams={{ q: searchQuery }}
-              singleRowScrollable
-            />
-
-            <div className="flex items-center pt-1">
-              <p className="text-xs tracking-wide text-muted-foreground sm:text-sm">
-                <span className="font-semibold text-secondary-foreground">
-                  {sortedBlogs.length}
-                </span>{" "}
-                posts
-              </p>
-            </div>
-
-            {!hasResults ? (
-              <div className="rounded-2xl border border-border/60 bg-card/45 px-5 py-8 text-secondary-foreground">
-                {searchQuery
-                  ? "Try a different keyword or clear filters."
-                  : "Try a different tag."}
-              </div>
-            ) : null}
-
-            {hasResults ? (
-              <>
-                <ol className="m-0 list-none space-y-3 p-0 pt-5 [&>li]:w-full [&>li]:max-w-none">
-                  {paginatedBlogs.items.map((blog) => {
-                    const blogWithContent = blogsWithContent.get(blog.slug);
-                    const publishedDate = formatPublishedDate(
-                      blogWithContent?.frontmatter.date,
-                    );
-                    const readingTime =
-                      blogWithContent?.frontmatter.readingTime;
-                    const tags = blogWithContent?.frontmatter.tags ?? [];
-
-                    return (
-                      <li key={blog.slug} className="w-full">
-                        <Link
-                          href={buildQueryHref("/blog", {
-                            ...blogListQuery,
-                            blog: blog.slug,
-                          })}
-                          className={cn(
-                            "group block w-full transition-transform duration-300 outline-none",
-                            "focus-visible:ring-4 focus-visible:ring-ring/30 focus-visible:ring-offset-2 focus-visible:ring-offset-secondary focus-visible:outline-none",
-                          )}
-                        >
-                          <BlogPostCard
-                            blog={blog}
-                            publishedDate={publishedDate}
-                            readingTime={readingTime}
-                            tags={tags}
-                          />
-                        </Link>
-                      </li>
-                    );
-                  })}
-                </ol>
-
-                <div className="pt-6">
-                  <PaginationNav
-                    basePath="/blog"
-                    currentPage={paginatedBlogs.currentPage}
-                    totalPages={paginatedBlogs.totalPages}
-                    query={{ tag: selectedTag, q: searchQuery }}
-                  />
-                </div>
-                <p className="pt-2 text-sm text-muted-foreground">
-                  {`Showing ${paginatedBlogs.startIndex + 1}-${paginatedBlogs.endIndex} of ${paginatedBlogs.totalItems}`}
-                </p>
-              </>
-            ) : null}
-          </section>
+          </Suspense>
         </SectionContentWrapper>
-
-        <Suspense>
-          <BlogModalHandler blogsMap={renderedBlogs} />
-        </Suspense>
       </main>
       <Footer />
     </>
-  );
-}
-
-function BlogPostCard({
-  blog,
-  publishedDate,
-  readingTime,
-  tags,
-}: {
-  blog: { slug: string; title: string; description: string; icon: string };
-  publishedDate: string | null;
-  readingTime?: number;
-  tags: string[];
-}) {
-  return (
-    <article className="flex w-full flex-col gap-4 rounded-xl border border-border/65 bg-card p-4 shadow-card transition-all duration-300 sm:flex-row sm:items-start sm:gap-5 sm:p-5 pointer-fine:group-hover:shadow-card-hover">
-      <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full border border-border/50 bg-secondary/80 text-foreground">
-        {getBlogIcon(blog.icon)}
-      </div>
-
-      <div className="min-w-0 flex-1 space-y-2">
-        <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-          {publishedDate ? <span>{publishedDate}</span> : null}
-          {publishedDate && readingTime ? (
-            <span className="text-border">|</span>
-          ) : null}
-          {readingTime ? <span>{readingTime} min read</span> : null}
-        </div>
-
-        <h2 className="font-mazaeni text-2xl leading-tight text-foreground transition-colors duration-300 group-hover:text-primary-hover">
-          {blog.title}
-        </h2>
-
-        <p className="line-clamp-2 text-sm leading-relaxed text-secondary-foreground">
-          {blog.description}
-        </p>
-
-        {tags.length > 0 ? (
-          <ChipOverflowRow
-            items={tags}
-            className="pt-1"
-            chipClassName="rounded-full bg-tertiary/80 px-2.5 py-1 text-xs font-medium text-tertiary-foreground"
-            moreClassName="rounded-full bg-tertiary/80 px-2.5 py-1 text-xs font-medium text-muted-foreground"
-          />
-        ) : null}
-      </div>
-    </article>
   );
 }

--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -1,30 +1,12 @@
-import { ChipOverflowRow } from "@/components/chip-overflow-row";
-import { FilterChipGroup } from "@/components/filter-chip-group";
 import { SectionContentWrapper } from "@/components/layout";
 import { ListPageHeader } from "@/components/list-page-header";
 import { mdxComponents } from "@/components/mdx";
-import { PaginationNav } from "@/components/pagination-nav";
-import {
-  ProjectModalHandler,
-  type RenderedProject,
-} from "@/components/project/index";
-import { SearchInput } from "@/components/search-input";
-import { SortSelect } from "@/components/sort-select";
-import { ViewModeToggle } from "@/components/view-mode-toggle";
+import { ProjectListClient } from "@/components/project/project-list-client";
+import { type RenderedProject } from "@/components/project/project-modal-handler";
 import { projectImageScope } from "@/content/projects/project-images";
-import { paginateItems, parsePageParam } from "@/lib/pagination";
-import {
-  getAllProjectCards,
-  getAllProjectsWithContent,
-  type ProjectCard,
-} from "@/lib/projects";
-import { buildQueryHref, readSingleParam } from "@/lib/query-params";
-import { searchProjects } from "@/lib/search";
-import { sortProjects, WORK_SORT_OPTIONS } from "@/lib/sorting";
-import { cn } from "@/lib/utils";
+import { getAllProjectsWithContent } from "@/lib/projects";
+import { sortByOrder } from "@/lib/sorting";
 import type { Metadata } from "next";
-import Image from "next/image";
-import Link from "next/link";
 import { MDXRemote } from "next-mdx-remote/rsc";
 import { Suspense } from "react";
 
@@ -41,58 +23,13 @@ export const metadata: Metadata = {
   },
 };
 
-const PROJECTS_PER_PAGE = 9;
-
-interface WorkIndexPageProps {
-  searchParams?: Promise<{
-    page?: string | string[];
-    category?: string | string[];
-    q?: string | string[];
-    sort?: string | string[];
-    view?: string | string[];
-  }>;
-}
-
-export default async function WorkIndexPage({
-  searchParams,
-}: WorkIndexPageProps) {
-  const resolvedSearchParams = await searchParams;
-  const selectedCategory = readSingleParam(resolvedSearchParams?.category);
-  const searchQuery = readSingleParam(resolvedSearchParams?.q);
-  const requestedSort = readSingleParam(resolvedSearchParams?.sort);
-  const requestedView = readSingleParam(resolvedSearchParams?.view);
-
-  const selectedSort = WORK_SORT_OPTIONS.some(
-    (option) => option.value === requestedSort,
-  )
-    ? requestedSort
-    : "recent";
-  const selectedView = requestedView === "list" ? "list" : "grid";
-  const sortParam = selectedSort === "recent" ? null : selectedSort;
-  const viewParam = selectedView === "grid" ? null : selectedView;
-
-  const projects = getAllProjectCards();
-  const categories = [
-    ...new Set(projects.map((project) => project.category)),
-  ].sort((a, b) => a.localeCompare(b));
-  const filteredProjects = selectedCategory
-    ? projects.filter((project) => project.category === selectedCategory)
-    : projects;
-  const searchedProjects = searchProjects(filteredProjects, searchQuery);
-  const sortedProjects = sortProjects(searchedProjects, selectedSort);
-  const totalPages = Math.max(
-    1,
-    Math.ceil(sortedProjects.length / PROJECTS_PER_PAGE),
-  );
-  const currentPage = parsePageParam(resolvedSearchParams?.page, totalPages);
-  const paginatedProjects = paginateItems(
-    sortedProjects,
-    currentPage,
-    PROJECTS_PER_PAGE,
-  );
-  const hasResults = paginatedProjects.totalItems > 0;
-
+export default async function WorkIndexPage() {
   const projectsWithContent = getAllProjectsWithContent();
+
+  const projectFrontmatters = sortByOrder(
+    Array.from(projectsWithContent.values()).map((p) => p.frontmatter),
+  );
+
   const renderedProjects = new Map<string, RenderedProject>();
   for (const [slug, project] of projectsWithContent) {
     renderedProjects.set(slug, {
@@ -107,14 +44,6 @@ export default async function WorkIndexPage({
     });
   }
 
-  const workListQuery = {
-    category: selectedCategory,
-    q: searchQuery,
-    sort: sortParam,
-    view: viewParam,
-    page: currentPage > 1 ? currentPage : null,
-  };
-
   return (
     <main id="main-content" className="relative min-h-screen bg-secondary">
       <SectionContentWrapper className="relative mt-[8rem] pt-4 pb-12 md:pt-5 md:pb-16">
@@ -122,233 +51,13 @@ export default async function WorkIndexPage({
           title="Work"
           subtitle="Products, experiments, and shipped systems."
         />
-
-        <section aria-label="Projects list" className="space-y-3.5">
-          <SearchInput
-            basePath="/work"
-            currentValue={searchQuery}
-            placeholder="Search by name, category, or technology…"
-            preserveParams={{
-              category: selectedCategory,
-              sort: sortParam,
-              view: viewParam,
-            }}
+        <Suspense>
+          <ProjectListClient
+            projectFrontmatters={projectFrontmatters}
+            renderedProjects={renderedProjects}
           />
-
-          <FilterChipGroup
-            title="Filter by category"
-            basePath="/work"
-            paramName="category"
-            selectedValue={selectedCategory}
-            options={categories.map((category) => ({
-              label: category,
-              value: category,
-            }))}
-            preserveParams={{
-              q: searchQuery,
-              sort: sortParam,
-              view: viewParam,
-            }}
-            singleRowScrollable
-          />
-
-          <div className="flex flex-col gap-2 pt-1 sm:flex-row sm:items-center sm:justify-between">
-            <p className="text-xs tracking-wide text-muted-foreground sm:text-sm">
-              <span className="font-semibold text-secondary-foreground">
-                {sortedProjects.length}
-              </span>{" "}
-              projects
-            </p>
-            <div className="flex items-center gap-2">
-              <SortSelect
-                basePath="/work"
-                currentValue={selectedSort}
-                options={WORK_SORT_OPTIONS}
-                preserveParams={{
-                  category: selectedCategory,
-                  q: searchQuery,
-                  view: viewParam,
-                }}
-              />
-              <ViewModeToggle
-                basePath="/work"
-                currentValue={selectedView}
-                preserveParams={{
-                  category: selectedCategory,
-                  q: searchQuery,
-                  sort: sortParam,
-                }}
-              />
-            </div>
-          </div>
-
-          {!hasResults ? (
-            <div className="rounded-2xl border border-border/60 bg-card/45 px-5 py-8 text-secondary-foreground">
-              {searchQuery
-                ? "Try a different keyword or clear filters."
-                : "Try a different category."}
-            </div>
-          ) : null}
-
-          {hasResults ? (
-            <>
-              <ol
-                className={cn(
-                  "m-0 list-none p-0 [&>li]:w-full [&>li]:max-w-none",
-                  selectedView === "grid"
-                    ? "grid gap-5 pt-5 sm:grid-cols-2 lg:grid-cols-3"
-                    : "space-y-3 pt-5",
-                )}
-              >
-                {paginatedProjects.items.map((project, index) => (
-                  <li
-                    key={project.slug}
-                    className={cn(
-                      "w-full",
-                      selectedView === "grid" && "h-full",
-                    )}
-                  >
-                    <Link
-                      href={buildQueryHref("/work", {
-                        ...workListQuery,
-                        project: project.slug,
-                      })}
-                      className={cn(
-                        "group block w-full transition-transform duration-300 outline-none",
-                        "focus-visible:ring-4 focus-visible:ring-ring/30 focus-visible:ring-offset-2 focus-visible:ring-offset-secondary focus-visible:outline-none",
-                        selectedView === "grid" && "h-full",
-                      )}
-                    >
-                      {selectedView === "grid" ? (
-                        <CompactProjectCard
-                          project={project}
-                          priority={index < 3}
-                        />
-                      ) : (
-                        <ListProjectCard
-                          project={project}
-                          priority={index < 2}
-                        />
-                      )}
-                    </Link>
-                  </li>
-                ))}
-              </ol>
-
-              <div className="pt-6">
-                <PaginationNav
-                  basePath="/work"
-                  currentPage={paginatedProjects.currentPage}
-                  totalPages={paginatedProjects.totalPages}
-                  query={{
-                    category: selectedCategory,
-                    q: searchQuery,
-                    sort: sortParam,
-                    view: viewParam,
-                  }}
-                />
-              </div>
-              <p className="pt-2 text-sm text-muted-foreground">
-                {`Showing ${paginatedProjects.startIndex + 1}-${paginatedProjects.endIndex} of ${paginatedProjects.totalItems}`}
-              </p>
-            </>
-          ) : null}
-        </section>
+        </Suspense>
       </SectionContentWrapper>
-
-      <Suspense>
-        <ProjectModalHandler projectsMap={renderedProjects} />
-      </Suspense>
     </main>
-  );
-}
-
-function CompactProjectCard({
-  project,
-  priority,
-}: {
-  project: ProjectCard;
-  priority?: boolean;
-}) {
-  return (
-    <article className="flex h-full flex-col overflow-hidden rounded-2xl border border-border/65 bg-card shadow-card transition-all duration-300 pointer-fine:group-hover:-translate-y-1 pointer-fine:group-hover:shadow-card-hover">
-      <div
-        className="relative aspect-video overflow-hidden"
-        style={{ backgroundColor: project.brandColor }}
-      >
-        <Image
-          src={project.image}
-          alt={`${project.title} preview`}
-          fill
-          sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
-          className="object-cover transition-transform duration-500 ease-out group-hover:scale-[1.04]"
-          priority={priority}
-        />
-        <span className="absolute bottom-3 left-3 rounded-full bg-background/88 px-3 py-1 text-xs font-medium text-foreground backdrop-blur-sm">
-          {project.category}
-        </span>
-      </div>
-
-      <div className="flex flex-1 flex-col gap-3 p-4">
-        <h2 className="font-mazaeni text-2xl leading-none text-foreground transition-colors duration-300 group-hover:text-primary-hover">
-          {project.title}
-        </h2>
-        <p className="line-clamp-2 text-sm leading-relaxed text-secondary-foreground">
-          {project.description}
-        </p>
-        <div className="mt-auto">
-          <ChipOverflowRow
-            items={project.skills}
-            className="pt-1"
-            chipClassName="rounded-full bg-tertiary/80 px-2.5 py-1 text-xs font-medium text-tertiary-foreground"
-            moreClassName="rounded-full bg-tertiary/80 px-2.5 py-1 text-xs font-medium text-muted-foreground"
-          />
-        </div>
-      </div>
-    </article>
-  );
-}
-
-function ListProjectCard({
-  project,
-  priority,
-}: {
-  project: ProjectCard;
-  priority?: boolean;
-}) {
-  return (
-    <article className="flex w-full flex-col gap-4 rounded-xl border border-border/65 bg-card p-3 shadow-card transition-all duration-300 [--outer-padding:0.75rem] [--outer-radius:var(--radius-xl)] sm:flex-row sm:items-stretch sm:gap-5 sm:p-4 sm:[--outer-padding:1rem] pointer-fine:group-hover:shadow-card-hover">
-      <div
-        className="rounded-inset relative aspect-video w-full shrink-0 overflow-hidden sm:aspect-auto sm:w-52 sm:self-stretch"
-        style={{ backgroundColor: project.brandColor }}
-      >
-        <Image
-          src={project.image}
-          alt={`${project.title} preview`}
-          fill
-          sizes="(max-width: 640px) 100vw, 13rem"
-          className="object-cover transition-transform duration-500 ease-out group-hover:scale-[1.04]"
-          priority={priority}
-        />
-      </div>
-
-      <div className="min-w-0 flex-1 space-y-2.5">
-        <p className="text-xs font-medium tracking-widest text-muted-foreground uppercase">
-          {project.category}
-        </p>
-        <h2 className="truncate font-mazaeni text-2xl leading-none text-foreground transition-colors duration-300 group-hover:text-primary-hover">
-          {project.title}
-        </h2>
-        <p className="line-clamp-2 text-sm leading-relaxed text-secondary-foreground">
-          {project.description}
-        </p>
-        <ChipOverflowRow
-          items={project.skills}
-          className="pt-1"
-          chipClassName="rounded-full bg-tertiary/80 px-2.5 py-1 text-xs font-medium text-tertiary-foreground"
-          moreClassName="rounded-full bg-tertiary/80 px-2.5 py-1 text-xs font-medium text-muted-foreground"
-        />
-      </div>
-    </article>
   );
 }

--- a/components/blog/blog-list-client.tsx
+++ b/components/blog/blog-list-client.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+import { BlogModalHandler, type RenderedBlog } from "@/components/blog";
+import { ChipOverflowRow } from "@/components/chip-overflow-row";
+import { FilterChipGroup } from "@/components/filter-chip-group";
+import { PaginationNav } from "@/components/pagination-nav";
+import { SearchInput } from "@/components/search-input";
+import { getBlogIcon } from "@/lib/blog-icons";
+import type { BlogFrontmatter } from "@/lib/blogs";
+import { DEFAULT_LOCALE } from "@/lib/constants";
+import { paginateItems, parsePageParam } from "@/lib/pagination";
+import { buildQueryHref } from "@/lib/query-params";
+import { searchBlogs } from "@/lib/search";
+import { cn } from "@/lib/utils";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { useMemo } from "react";
+
+const BLOGS_PER_PAGE = 9;
+
+function formatPublishedDate(date?: string) {
+  if (!date) return null;
+  return new Intl.DateTimeFormat(DEFAULT_LOCALE, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  }).format(new Date(`${date}T00:00:00Z`));
+}
+
+interface BlogListClientProps {
+  blogFrontmatters: BlogFrontmatter[];
+  renderedBlogs: Map<string, RenderedBlog>;
+}
+
+export function BlogListClient({
+  blogFrontmatters,
+  renderedBlogs,
+}: BlogListClientProps) {
+  const searchParams = useSearchParams();
+  const selectedTag = searchParams.get("tag") ?? undefined;
+  const searchQuery = searchParams.get("q") ?? undefined;
+  const rawPage = searchParams.get("page") ?? undefined;
+
+  const tagOptions = useMemo(
+    () => [...new Set(blogFrontmatters.flatMap((b) => b.tags ?? []))],
+    [blogFrontmatters],
+  );
+
+  const filteredBlogs = useMemo(
+    () =>
+      selectedTag
+        ? blogFrontmatters.filter((b) => (b.tags ?? []).includes(selectedTag))
+        : blogFrontmatters,
+    [blogFrontmatters, selectedTag],
+  );
+
+  const searchedBlogs = useMemo(
+    () => searchBlogs(filteredBlogs, searchQuery, (b) => b.tags ?? []),
+    [filteredBlogs, searchQuery],
+  );
+
+  const totalPages = Math.max(
+    1,
+    Math.ceil(searchedBlogs.length / BLOGS_PER_PAGE),
+  );
+  const currentPage = parsePageParam(rawPage, totalPages);
+  const paginatedBlogs = paginateItems(
+    searchedBlogs,
+    currentPage,
+    BLOGS_PER_PAGE,
+  );
+  const hasResults = paginatedBlogs.totalItems > 0;
+
+  const blogListQuery = {
+    tag: selectedTag,
+    q: searchQuery,
+    page: currentPage > 1 ? currentPage : null,
+  };
+
+  return (
+    <>
+      <section aria-label="Blog posts list" className="space-y-3.5">
+        <SearchInput
+          basePath="/blog"
+          currentValue={searchQuery}
+          placeholder="Search by title, tag, or description…"
+          preserveParams={{ tag: selectedTag }}
+        />
+
+        <FilterChipGroup
+          title="Filter by tag"
+          basePath="/blog"
+          paramName="tag"
+          selectedValue={selectedTag}
+          options={tagOptions.map((tag) => ({ label: tag, value: tag }))}
+          preserveParams={{ q: searchQuery }}
+          singleRowScrollable
+        />
+
+        <div className="flex items-center pt-1">
+          <p className="text-xs tracking-wide text-muted-foreground sm:text-sm">
+            <span className="font-semibold text-secondary-foreground">
+              {searchedBlogs.length}
+            </span>{" "}
+            posts
+          </p>
+        </div>
+
+        {!hasResults ? (
+          <div className="rounded-2xl border border-border/60 bg-card/45 px-5 py-8 text-secondary-foreground">
+            {searchQuery
+              ? "Try a different keyword or clear filters."
+              : "Try a different tag."}
+          </div>
+        ) : null}
+
+        {hasResults ? (
+          <>
+            <ol className="m-0 list-none space-y-3 p-0 pt-5 [&>li]:w-full [&>li]:max-w-none">
+              {paginatedBlogs.items.map((blog) => (
+                <li key={blog.slug} className="w-full">
+                  <Link
+                    href={buildQueryHref("/blog", {
+                      ...blogListQuery,
+                      blog: blog.slug,
+                    })}
+                    className={cn(
+                      "group block w-full transition-transform duration-300 outline-none",
+                      "focus-visible:ring-4 focus-visible:ring-ring/30 focus-visible:ring-offset-2 focus-visible:ring-offset-secondary focus-visible:outline-none",
+                    )}
+                  >
+                    <BlogPostCard
+                      blog={blog}
+                      publishedDate={formatPublishedDate(blog.date)}
+                      readingTime={blog.readingTime}
+                      tags={blog.tags ?? []}
+                    />
+                  </Link>
+                </li>
+              ))}
+            </ol>
+
+            <div className="pt-6">
+              <PaginationNav
+                basePath="/blog"
+                currentPage={paginatedBlogs.currentPage}
+                totalPages={paginatedBlogs.totalPages}
+                query={{ tag: selectedTag, q: searchQuery }}
+              />
+            </div>
+            <p className="pt-2 text-sm text-muted-foreground">
+              {`Showing ${paginatedBlogs.startIndex + 1}-${paginatedBlogs.endIndex} of ${paginatedBlogs.totalItems}`}
+            </p>
+          </>
+        ) : null}
+      </section>
+
+      <BlogModalHandler blogsMap={renderedBlogs} />
+    </>
+  );
+}
+
+function BlogPostCard({
+  blog,
+  publishedDate,
+  readingTime,
+  tags,
+}: {
+  blog: { slug: string; title: string; description: string; icon: string };
+  publishedDate: string | null;
+  readingTime?: number;
+  tags: string[];
+}) {
+  return (
+    <article className="flex w-full flex-col gap-4 rounded-xl border border-border/65 bg-card p-4 shadow-card transition-all duration-300 sm:flex-row sm:items-start sm:gap-5 sm:p-5 pointer-fine:group-hover:shadow-card-hover">
+      <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full border border-border/50 bg-secondary/80 text-foreground">
+        {getBlogIcon(blog.icon)}
+      </div>
+
+      <div className="min-w-0 flex-1 space-y-2">
+        <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+          {publishedDate ? <span>{publishedDate}</span> : null}
+          {publishedDate && readingTime ? (
+            <span className="text-border">|</span>
+          ) : null}
+          {readingTime ? <span>{readingTime} min read</span> : null}
+        </div>
+
+        <h2 className="font-mazaeni text-2xl leading-tight text-foreground transition-colors duration-300 group-hover:text-primary-hover">
+          {blog.title}
+        </h2>
+
+        <p className="line-clamp-2 text-sm leading-relaxed text-secondary-foreground">
+          {blog.description}
+        </p>
+
+        {tags.length > 0 ? (
+          <ChipOverflowRow
+            items={tags}
+            className="pt-1"
+            chipClassName="rounded-full bg-tertiary/80 px-2.5 py-1 text-xs font-medium text-tertiary-foreground"
+            moreClassName="rounded-full bg-tertiary/80 px-2.5 py-1 text-xs font-medium text-muted-foreground"
+          />
+        ) : null}
+      </div>
+    </article>
+  );
+}

--- a/components/contact/contact.tsx
+++ b/components/contact/contact.tsx
@@ -225,13 +225,13 @@ export function Contact({
                             onChange={(e) => field.handleChange(e.target.value)}
                             placeholder="Let's chat!"
                             rows={6}
-                            maxLength={100}
+                            maxLength={1000}
                             aria-invalid={isInvalid}
                             required
                           />
                           <InputGroupAddon align="block-end">
                             <InputGroupText className="tabular-nums">
-                              {field.state.value.length}/100 characters
+                              {field.state.value.length}/1,000 characters
                             </InputGroupText>
                           </InputGroupAddon>
                         </InputGroup>

--- a/components/project/project-list-client.tsx
+++ b/components/project/project-list-client.tsx
@@ -1,0 +1,318 @@
+"use client";
+
+import { ChipOverflowRow } from "@/components/chip-overflow-row";
+import { FilterChipGroup } from "@/components/filter-chip-group";
+import { PaginationNav } from "@/components/pagination-nav";
+import {
+  ProjectModalHandler,
+  type RenderedProject,
+} from "@/components/project/index";
+import { SearchInput } from "@/components/search-input";
+import { SortSelect } from "@/components/sort-select";
+import { ViewModeToggle } from "@/components/view-mode-toggle";
+import { paginateItems, parsePageParam } from "@/lib/pagination";
+import type { ProjectFrontmatter } from "@/lib/projects";
+import { buildQueryHref } from "@/lib/query-params";
+import { searchProjects } from "@/lib/search";
+import { sortProjects, WORK_SORT_OPTIONS } from "@/lib/sorting";
+import { cn } from "@/lib/utils";
+import Image from "next/image";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { useMemo } from "react";
+
+const PROJECTS_PER_PAGE = 9;
+
+interface ProjectListClientProps {
+  projectFrontmatters: ProjectFrontmatter[];
+  renderedProjects: Map<string, RenderedProject>;
+}
+
+export function ProjectListClient({
+  projectFrontmatters,
+  renderedProjects,
+}: ProjectListClientProps) {
+  const searchParams = useSearchParams();
+  const selectedCategory = searchParams.get("category") ?? undefined;
+  const searchQuery = searchParams.get("q") ?? undefined;
+  const requestedSort = searchParams.get("sort") ?? undefined;
+  const requestedView = searchParams.get("view") ?? undefined;
+  const rawPage = searchParams.get("page") ?? undefined;
+
+  const selectedSort = WORK_SORT_OPTIONS.some(
+    (option) => option.value === requestedSort,
+  )
+    ? requestedSort
+    : "recent";
+  const selectedView = requestedView === "list" ? "list" : "grid";
+  const sortParam = selectedSort === "recent" ? null : selectedSort;
+  const viewParam = selectedView === "grid" ? null : selectedView;
+
+  const categories = useMemo(
+    () =>
+      [...new Set(projectFrontmatters.map((p) => p.category))].sort((a, b) =>
+        a.localeCompare(b),
+      ),
+    [projectFrontmatters],
+  );
+
+  const filteredProjects = useMemo(
+    () =>
+      selectedCategory
+        ? projectFrontmatters.filter((p) => p.category === selectedCategory)
+        : projectFrontmatters,
+    [projectFrontmatters, selectedCategory],
+  );
+
+  const searchedProjects = useMemo(
+    () => searchProjects(filteredProjects, searchQuery),
+    [filteredProjects, searchQuery],
+  );
+
+  const sortedProjects = useMemo(
+    () => sortProjects(searchedProjects, selectedSort),
+    [searchedProjects, selectedSort],
+  );
+
+  const totalPages = Math.max(
+    1,
+    Math.ceil(sortedProjects.length / PROJECTS_PER_PAGE),
+  );
+  const currentPage = parsePageParam(rawPage, totalPages);
+  const paginatedProjects = paginateItems(
+    sortedProjects,
+    currentPage,
+    PROJECTS_PER_PAGE,
+  );
+  const hasResults = paginatedProjects.totalItems > 0;
+
+  const workListQuery = {
+    category: selectedCategory,
+    q: searchQuery,
+    sort: sortParam,
+    view: viewParam,
+    page: currentPage > 1 ? currentPage : null,
+  };
+
+  return (
+    <>
+      <section aria-label="Projects list" className="space-y-3.5">
+        <SearchInput
+          basePath="/work"
+          currentValue={searchQuery}
+          placeholder="Search by name, category, or technology…"
+          preserveParams={{
+            category: selectedCategory,
+            sort: sortParam,
+            view: viewParam,
+          }}
+        />
+
+        <FilterChipGroup
+          title="Filter by category"
+          basePath="/work"
+          paramName="category"
+          selectedValue={selectedCategory}
+          options={categories.map((category) => ({
+            label: category,
+            value: category,
+          }))}
+          preserveParams={{
+            q: searchQuery,
+            sort: sortParam,
+            view: viewParam,
+          }}
+          singleRowScrollable
+        />
+
+        <div className="flex flex-col gap-2 pt-1 sm:flex-row sm:items-center sm:justify-between">
+          <p className="text-xs tracking-wide text-muted-foreground sm:text-sm">
+            <span className="font-semibold text-secondary-foreground">
+              {sortedProjects.length}
+            </span>{" "}
+            projects
+          </p>
+          <div className="flex items-center gap-2">
+            <SortSelect
+              basePath="/work"
+              currentValue={selectedSort}
+              options={WORK_SORT_OPTIONS}
+              preserveParams={{
+                category: selectedCategory,
+                q: searchQuery,
+                view: viewParam,
+              }}
+            />
+            <ViewModeToggle
+              basePath="/work"
+              currentValue={selectedView}
+              preserveParams={{
+                category: selectedCategory,
+                q: searchQuery,
+                sort: sortParam,
+              }}
+            />
+          </div>
+        </div>
+
+        {!hasResults ? (
+          <div className="rounded-2xl border border-border/60 bg-card/45 px-5 py-8 text-secondary-foreground">
+            {searchQuery
+              ? "Try a different keyword or clear filters."
+              : "Try a different category."}
+          </div>
+        ) : null}
+
+        {hasResults ? (
+          <>
+            <ol
+              className={cn(
+                "m-0 list-none p-0 [&>li]:w-full [&>li]:max-w-none",
+                selectedView === "grid"
+                  ? "grid gap-5 pt-5 sm:grid-cols-2 lg:grid-cols-3"
+                  : "space-y-3 pt-5",
+              )}
+            >
+              {paginatedProjects.items.map((project, index) => (
+                <li
+                  key={project.slug}
+                  className={cn("w-full", selectedView === "grid" && "h-full")}
+                >
+                  <Link
+                    href={buildQueryHref("/work", {
+                      ...workListQuery,
+                      project: project.slug,
+                    })}
+                    className={cn(
+                      "group block w-full transition-transform duration-300 outline-none",
+                      "focus-visible:ring-4 focus-visible:ring-ring/30 focus-visible:ring-offset-2 focus-visible:ring-offset-secondary focus-visible:outline-none",
+                      selectedView === "grid" && "h-full",
+                    )}
+                  >
+                    {selectedView === "grid" ? (
+                      <CompactProjectCard
+                        project={project}
+                        priority={index < 3}
+                      />
+                    ) : (
+                      <ListProjectCard project={project} priority={index < 2} />
+                    )}
+                  </Link>
+                </li>
+              ))}
+            </ol>
+
+            <div className="pt-6">
+              <PaginationNav
+                basePath="/work"
+                currentPage={paginatedProjects.currentPage}
+                totalPages={paginatedProjects.totalPages}
+                query={{
+                  category: selectedCategory,
+                  q: searchQuery,
+                  sort: sortParam,
+                  view: viewParam,
+                }}
+              />
+            </div>
+            <p className="pt-2 text-sm text-muted-foreground">
+              {`Showing ${paginatedProjects.startIndex + 1}-${paginatedProjects.endIndex} of ${paginatedProjects.totalItems}`}
+            </p>
+          </>
+        ) : null}
+      </section>
+
+      <ProjectModalHandler projectsMap={renderedProjects} />
+    </>
+  );
+}
+
+function CompactProjectCard({
+  project,
+  priority,
+}: {
+  project: ProjectFrontmatter;
+  priority?: boolean;
+}) {
+  return (
+    <article className="flex h-full flex-col overflow-hidden rounded-2xl border border-border/65 bg-card shadow-card transition-all duration-300 pointer-fine:group-hover:-translate-y-1 pointer-fine:group-hover:shadow-card-hover">
+      <div
+        className="relative aspect-video overflow-hidden"
+        style={{ backgroundColor: project.brandColor }}
+      >
+        <Image
+          src={project.image}
+          alt={`${project.title} preview`}
+          fill
+          sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+          className="object-cover transition-transform duration-500 ease-out group-hover:scale-[1.04]"
+          priority={priority}
+        />
+        <span className="absolute bottom-3 left-3 rounded-full bg-background/88 px-3 py-1 text-xs font-medium text-foreground backdrop-blur-sm">
+          {project.category}
+        </span>
+      </div>
+
+      <div className="flex flex-1 flex-col gap-3 p-4">
+        <h2 className="font-mazaeni text-2xl leading-none text-foreground transition-colors duration-300 group-hover:text-primary-hover">
+          {project.title}
+        </h2>
+        <p className="line-clamp-2 text-sm leading-relaxed text-secondary-foreground">
+          {project.description}
+        </p>
+        <div className="mt-auto">
+          <ChipOverflowRow
+            items={project.skills}
+            className="pt-1"
+            chipClassName="rounded-full bg-tertiary/80 px-2.5 py-1 text-xs font-medium text-tertiary-foreground"
+            moreClassName="rounded-full bg-tertiary/80 px-2.5 py-1 text-xs font-medium text-muted-foreground"
+          />
+        </div>
+      </div>
+    </article>
+  );
+}
+
+function ListProjectCard({
+  project,
+  priority,
+}: {
+  project: ProjectFrontmatter;
+  priority?: boolean;
+}) {
+  return (
+    <article className="flex w-full flex-col gap-4 rounded-xl border border-border/65 bg-card p-3 shadow-card transition-all duration-300 [--outer-padding:0.75rem] [--outer-radius:var(--radius-xl)] sm:flex-row sm:items-stretch sm:gap-5 sm:p-4 sm:[--outer-padding:1rem] pointer-fine:group-hover:shadow-card-hover">
+      <div
+        className="rounded-inset relative aspect-video w-full shrink-0 overflow-hidden sm:aspect-auto sm:w-52 sm:self-stretch"
+        style={{ backgroundColor: project.brandColor }}
+      >
+        <Image
+          src={project.image}
+          alt={`${project.title} preview`}
+          fill
+          sizes="(max-width: 640px) 100vw, 13rem"
+          className="object-cover transition-transform duration-500 ease-out group-hover:scale-[1.04]"
+          priority={priority}
+        />
+      </div>
+
+      <div className="min-w-0 flex-1 space-y-2.5">
+        <p className="text-xs font-medium tracking-widest text-muted-foreground uppercase">
+          {project.category}
+        </p>
+        <h2 className="truncate font-mazaeni text-2xl leading-none text-foreground transition-colors duration-300 group-hover:text-primary-hover">
+          {project.title}
+        </h2>
+        <p className="line-clamp-2 text-sm leading-relaxed text-secondary-foreground">
+          {project.description}
+        </p>
+        <ChipOverflowRow
+          items={project.skills}
+          className="pt-1"
+          chipClassName="rounded-full bg-tertiary/80 px-2.5 py-1 text-xs font-medium text-tertiary-foreground"
+          moreClassName="rounded-full bg-tertiary/80 px-2.5 py-1 text-xs font-medium text-muted-foreground"
+        />
+      </div>
+    </article>
+  );
+}

--- a/lib/contact-validation.ts
+++ b/lib/contact-validation.ts
@@ -24,8 +24,8 @@ export const validateMessage = (val: string): string | undefined => {
   if (!val || val.trim().length === 0) {
     return "Message is required.";
   }
-  if (val.length > 100) {
-    return "Message must not exceed 100 characters.";
+  if (val.length > 1000) {
+    return "Message must not exceed 1000 characters.";
   }
   return undefined;
 };

--- a/lib/content.ts
+++ b/lib/content.ts
@@ -3,6 +3,8 @@ import matter from "gray-matter";
 import path from "path";
 import { z } from "zod";
 
+export { sortByOrder } from "@/lib/sorting";
+
 /**
  * Get all content slugs from a directory of MDX files.
  */
@@ -83,17 +85,4 @@ export function getContentWithContent<T, U = T>(
     console.error(`Error reading ${context} ${slug}:`, error);
     return null;
   }
-}
-
-/**
- * Sort items by optional order field (lower first, items with order before those without).
- */
-export function sortByOrder<T extends { order?: number }>(items: T[]): T[] {
-  return [...items].sort((a, b) => {
-    if (a.order !== undefined && b.order !== undefined)
-      return a.order - b.order;
-    if (a.order !== undefined) return -1;
-    if (b.order !== undefined) return 1;
-    return 0;
-  });
 }

--- a/lib/dataTypes.ts
+++ b/lib/dataTypes.ts
@@ -13,7 +13,7 @@ export const emailSchema = z.object({
   message: z
     .string()
     .min(1, "Message is required.")
-    .max(100, "Message must not exceed 100 characters."),
+    .max(1000, "Message must not exceed 1000 characters."),
   // Honeypot field - should always be empty (bots fill this in)
   website: z.string().max(0, "Invalid submission.").optional(),
 });

--- a/lib/sorting.ts
+++ b/lib/sorting.ts
@@ -1,4 +1,12 @@
-import { sortByOrder } from "@/lib/content";
+export function sortByOrder<T extends { order?: number }>(items: T[]): T[] {
+  return [...items].sort((a, b) => {
+    if (a.order !== undefined && b.order !== undefined)
+      return a.order - b.order;
+    if (a.order !== undefined) return -1;
+    if (b.order !== undefined) return 1;
+    return 0;
+  });
+}
 
 export interface SortOption {
   label: string;


### PR DESCRIPTION
## Summary

- `/blog` and `/work` were server-rendered on every request (`ƒ Dynamic`) because the page components read `searchParams` directly
- All URL-driven UI state (search, filters, sort, view, pagination, modal) is moved into new `"use client"` components (`BlogListClient`, `ProjectListClient`) that use `useSearchParams()` instead
- The RSC pages now only load data and pre-render MDX at build time -- no runtime dependency on query params
- `sortByOrder` is moved from `lib/content.ts` (which imports `fs`) into `lib/sorting.ts` so sorting utilities are safe to bundle in client components

## Result

Both routes now prerender at build time:

```
○ /blog   (Static)
○ /work   (Static)
```

All existing functionality is preserved: search, tag/category filters, sort, grid/list view, pagination, and modal overlays all work the same -- state just lives in the client instead of on the server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Contact page accessible from the main navigation.
  * Contact form now validates message length (maximum 100 characters).

* **Navigation Updates**
  * Main navigation menu updated: Contact link replaces previous navigation item.
  * Updated sitemap to include the new Contact route.

* **UI/UX Improvements**
  * Contact form button styled with larger size and updated label text.
  * Enhanced Contact form with customizable intro section and error handling.
  * Improved error field styling for better visual clarity.

* **Tests**
  * Added end-to-end tests for the new Contact page and updated navigation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->